### PR TITLE
[codex] Improve bootstrap operations flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ Discord からも生成できます。
 /codex-generate-proposal title:Project Name
 ```
 
+Bootstrap flow:
+
+```bash
+npm run bootstrap:project -- --title "Project Name"
+npm run apply:bootstrap -- --title "Project Name"
+npm run apply:bootstrap -- --title "Project Name" --apply
+```
+
 詳細:
 
 - `docs/proposal-template-generator.md`
@@ -197,3 +205,4 @@ Discord からも生成できます。
 - `docs/notion-spec-creation-from-draft.md`
 - `docs/project-bootstrap-flow.md`
 - `docs/project-bootstrap-apply-flow.md`
+`/codex-apply-bootstrap` は、`title` から最新の spec / issue seeds を解決するか、`spec_file` と `issue_seed_file` を直接指定して使えます。

--- a/context.md
+++ b/context.md
@@ -34,6 +34,12 @@
 - spec draft から Notion `Specs` page を dry-run / apply で作成できる導線を CLI と Discord に追加済み
 - 新規企画の proposal / spec / issue seeds をまとめて起こすブートストラップ導線を CLI と Discord に追加済み
 - bootstrap 後の Notion / GitHub 反映をまとめて dry-run / apply できる導線を CLI と Discord に追加済み
+- `apply:bootstrap` はタイトルから最新生成物を解決するか、spec / issue-seeds のファイル名を明示して実行できる
+- bootstrap から Notion / GitHub 反映までの dry-run 表示、ファイル指定 alias、実運用手順を整理済み
+- `Bootstrap Resolution Sample` で `apply:bootstrap --apply` を実行し、Notion `Specs` page と GitHub Issue #7-#10 の作成に成功済み
+- `sync:tasks` を本実行し、GitHub Issue #7-#10 を Notion `Tasks` に作成済み
+- Discord slash commands を再登録し、Bot `チャッピー#1662` の起動 ready を確認済み
+- Discord の `/codex-bootstrap-project` と `/codex-apply-bootstrap` は、スマホ確認向けに日本語の短い要約表示へ変更済み
 
 ### Incomplete Items
 
@@ -44,7 +50,7 @@
 
 ### Next Priority
 
-- bootstrap から Notion / GitHub 反映までの実運用手順を固める
+- bootstrap から Notion / GitHub 反映までの実運用手順と apply 対象ファイル指定ルールを固める
 
 ## Active Deliverables
 
@@ -81,10 +87,10 @@
 
 ## Immediate Next Steps
 
-1. `NOTION_API_TOKEN` を使った bootstrap apply 本実行フローを確認する
-2. `GITHUB_TOKEN` を使った bootstrap apply 本実行フローを確認する
-3. `bootstrap:project` と `apply:bootstrap` の実運用手順を整理する
-4. 必要なら proposal / spec / issue-seeds / issue-creation コマンドの入力項目を拡張する
+1. Discord から `/codex-bootstrap-project` と `/codex-apply-bootstrap` の日本語短縮表示を再確認する
+2. サンプル企画 `Bootstrap Resolution Sample` を残すか、検証用として削除するか判断する
+3. Notion `Tasks` に作成された Issue #7-#10 の Project relation や補足項目を必要に応じて整える
+4. 企画テンプレートの genre / platform / audience 入力項目を実運用に合わせて拡張する
 
 ## Actionable Tasks (2026-04-21)
 
@@ -135,6 +141,7 @@
 - 2026-04-23: spec draft から Notion `Specs` page を CLI と Discord で作成できるようにする
 - 2026-04-24: 新規企画の proposal / spec / issue seeds を CLI と Discord でまとめて生成できるようにする
 - 2026-04-24: bootstrap 後の Notion / GitHub 反映を CLI と Discord でまとめて dry-run / apply できるようにする
+- 2026-04-24: `apply:bootstrap` は日付固定ではなく、タイトル一致の最新生成物または明示ファイル指定で反映できるようにする
 
 ## References
 
@@ -172,6 +179,12 @@
 - Notion `Specs` page 作成も CLI と Discord の両方から使える
 - 新規企画のブートストラップも CLI と Discord の両方から使える
 - bootstrap 後の一括反映も CLI と Discord の両方から使える
+- `apply:bootstrap` は title 指定、camelCase ファイル指定、snake_case ファイル指定で dry-run できる
+- 本実行前に Notion / GitHub の作成予定内容を preview で確認する運用にした
+- `Bootstrap Resolution Sample` の Notion Spec と GitHub Issue #7-#10 は作成済みで、`sync:tasks:dry` では #7-#10 の Notion `Tasks` 新規作成予定まで確認済み
+- GitHub Issue #7-#10 は `sync:tasks` 本実行で Notion `Tasks` に作成済み
+- Discord Bot は起動 ready まで確認済み。次は Discord クライアント側から dry-run 表示を確認する
+- Discord の bootstrap / apply bootstrap 返信は CLI 詳細ログをそのまま出さず、日本語の要約だけを返す
 - 次回は Notion `Specs` 連携と GitHub / Notion 同期まで含めた実運用を固める
 - 情報を更新するときは、先に正本が Notion / GitHub / `context.md` のどれかを確認する
 - GitHub と Notion の二重更新は避け、`Tasks` の必要項目だけを同期する

--- a/docs/discord-bot-reference.md
+++ b/docs/discord-bot-reference.md
@@ -317,7 +317,9 @@ Last updated: 2026-04-22
 
 入力:
 
-- `title` 必須
+- `title` 任意
+- `spec_file` 任意
+- `issue_seed_file` 任意
 - `dry_run` 任意
 
 例:
@@ -325,13 +327,22 @@ Last updated: 2026-04-22
 ```text
 /codex-apply-bootstrap title:Neon Courier
 /codex-apply-bootstrap title:Neon Courier dry_run:false
+/codex-apply-bootstrap spec_file:20260424-neon-courier-spec.md issue_seed_file:20260424-neon-courier-issue-seeds.md
 ```
 
 挙動:
 
 - 既定は `dry_run:true`
+- `title` だけを指定した場合は、該当タイトルの最新 spec / issue seeds を自動で探す
+- `spec_file` と `issue_seed_file` を両方指定すると、対象ファイルを固定して反映できる
 - `dry_run:true` では Notion Spec 作成 dry-run と GitHub Issue 作成 dry-run をまとめて返す
 - `dry_run:false` では両方を本実行する
+
+制限:
+
+- 指定なしでは `dry_run:true`
+- `dry_run:false` は `DISCORD_NOTION_APPLY_CHANNEL_IDS` と `DISCORD_ISSUE_APPLY_CHANNEL_IDS` の条件を満たすチャンネルでのみ使う
+- 本実行前に dry-run の preview を確認する
 
 補足:
 

--- a/docs/discord-bot-setup.md
+++ b/docs/discord-bot-setup.md
@@ -79,7 +79,7 @@ npm run dev
 - `/codex-env`: 現在の guild / channel / user ID と allowlist 設定を確認する
 - `/codex-generate-proposal`: ゲーム企画書ドラフトを生成する
 - `/codex-bootstrap-project`: proposal / spec / issue seeds をまとめて生成する
-- `/codex-apply-bootstrap`: bootstrap 済みの spec / issue seeds をまとめて反映する
+- `/codex-apply-bootstrap`: bootstrap 済みの spec / issue seeds をまとめて反映する。title から最新ファイルを探すか、ファイル名を直接指定できる
 - `/codex-generate-issue-seeds`: 企画書ドラフトから GitHub Issue 下書きを生成する
 - `/codex-generate-spec`: 企画書ドラフトから spec draft を生成する
 - `/codex-create-spec-in-notion`: spec draft から Notion `Specs` page を作成する
@@ -89,6 +89,7 @@ npm run dev
 - `/codex-sync-tasks` の `dry_run:false` は `DISCORD_SYNC_APPLY_CHANNEL_IDS` のチャンネルでだけ許可する
 - `/codex-create-spec-in-notion` の `dry_run:false` は `DISCORD_NOTION_APPLY_CHANNEL_IDS` のチャンネルでだけ許可する
 - `/codex-create-issues-from-seeds` の `dry_run:false` は `DISCORD_ISSUE_APPLY_CHANNEL_IDS` のチャンネルでだけ許可する
+- `/codex-apply-bootstrap` の `dry_run:false` は Notion と GitHub の両方に反映するため、`DISCORD_NOTION_APPLY_CHANNEL_IDS` と `DISCORD_ISSUE_APPLY_CHANNEL_IDS` の両方の条件を満たすチャンネルでだけ許可する
 
 ## Logging
 
@@ -111,6 +112,7 @@ npm run dev
 - `DISCORD_SYNC_APPLY_CHANNEL_IDS` を設定すると、`/codex-sync-tasks dry_run:false` の本実行チャンネルを限定できます
 - `DISCORD_NOTION_APPLY_CHANNEL_IDS` を設定すると、`/codex-create-spec-in-notion dry_run:false` の本実行チャンネルを限定できます
 - `DISCORD_ISSUE_APPLY_CHANNEL_IDS` を設定すると、`/codex-create-issues-from-seeds dry_run:false` の本実行チャンネルを限定できます
+- `/codex-apply-bootstrap dry_run:false` は Notion Spec 作成と GitHub Issue 作成をまとめて行うため、Notion / Issue 両方の apply channel 設定を満たす必要があります
 - 複数指定する場合は `123,456,789` のようにカンマ区切りで入れます
 - 拒否された操作は `runtime/discord-command-log.jsonl` に `access_denied` として残ります
 

--- a/docs/project-bootstrap-apply-flow.md
+++ b/docs/project-bootstrap-apply-flow.md
@@ -10,6 +10,13 @@
 npm run apply:bootstrap -- --title "Project Name"
 ```
 
+特定ファイルを指定する場合:
+
+```bash
+npm run apply:bootstrap -- --specFile 20260424-project-name-spec.md --issueSeedFile 20260424-project-name-issue-seeds.md
+npm run apply:bootstrap -- --spec_file 20260424-project-name-spec.md --issue_seed_file 20260424-project-name-issue-seeds.md
+```
+
 本実行:
 
 ```bash
@@ -21,17 +28,28 @@ Discord から実行する場合:
 ```text
 /codex-apply-bootstrap title:Project Name
 /codex-apply-bootstrap title:Project Name dry_run:false
+/codex-apply-bootstrap spec_file:20260424-project-name-spec.md issue_seed_file:20260424-project-name-issue-seeds.md
 ```
 
 ## Behavior
 
 - 既定は dry-run
+- `title` だけを渡した場合は、該当タイトルの最新 spec / issue seeds を自動で探す
+- `spec_file` と `issue_seed_file` を指定すると、そのファイルを使う
 - dry-run では Notion Spec 作成 dry-run と GitHub Issue 作成 dry-run をまとめて返す
+- dry-run は spec title、source file、body preview、作成予定 Issue の title / labels / body preview を返す
 - `--apply` または `dry_run:false` では両方を本実行する
+
+## File Resolution Rule
+
+- `--title` のみ指定した場合は、タイトル slug に一致する最新の spec / issue seeds を使う
+- `--specFile` と `--issueSeedFile` を指定した場合は、そのファイルを使う
+- CLI では `--spec_file` と `--issue_seed_file` も同じ意味で使える
+- Discord では `spec_file` と `issue_seed_file` を使う
 
 ## Expected Files
 
-同じ日付で生成済みの以下ファイルを前提にする。
+生成済みの以下ファイルを前提にする。
 
 - `drafts/specs/YYYYMMDD-project-name-spec.md`
 - `drafts/issue-seeds/YYYYMMDD-project-name-issue-seeds.md`
@@ -39,5 +57,6 @@ Discord から実行する場合:
 ## Notes
 
 - `bootstrap:project` 実行後の反映導線
+- 日付をまたいだ場合でも、タイトル一致の最新ファイルを解決できる
 - Notion と GitHub の本実行条件は両方満たす必要がある
 - 本実行には `NOTION_API_TOKEN` と `GITHUB_TOKEN` が必要

--- a/docs/project-bootstrap-flow.md
+++ b/docs/project-bootstrap-flow.md
@@ -26,6 +26,12 @@ npm run apply:bootstrap -- --title "Project Name"
 /codex-apply-bootstrap title:Project Name
 ```
 
+必要なら bootstrap 後に生成済みファイルを直接指定して反映できる:
+
+```text
+/codex-apply-bootstrap spec_file:20260424-project-name-spec.md issue_seed_file:20260424-project-name-issue-seeds.md
+```
+
 ## Output
 
 まとめて生成されるもの:
@@ -51,6 +57,16 @@ npm run apply:bootstrap -- --title "Project Name"
 3. spec draft を詰める
 4. issue seeds を確認する
 5. 必要なら GitHub Issue と Notion `Specs` へ流す
+
+## Recommended Operation
+
+1. `npm run bootstrap:project -- --title "Project Name"` で下書きを生成する
+2. `drafts/proposals/` の proposal を確認する
+3. `drafts/specs/` の spec draft を確認する
+4. `drafts/issue-seeds/` の Issue seeds を確認する
+5. `npm run apply:bootstrap -- --title "Project Name"` で dry-run する
+6. dry-run の Notion / GitHub preview を確認する
+7. 問題がなければ `npm run apply:bootstrap -- --title "Project Name" --apply` を実行する
 
 ## Notes
 

--- a/docs/superpowers/plans/2026-04-25-bootstrap-operations.md
+++ b/docs/superpowers/plans/2026-04-25-bootstrap-operations.md
@@ -1,0 +1,853 @@
+# Bootstrap Operations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `bootstrap:project` から `apply:bootstrap` までを、CLI と Discord の両方で安全に実運用できる状態にする。
+
+**Architecture:** 既存の生成スクリプト群はそのまま活かし、`src/apply-bootstrap-project.js` を「成果物解決・事前確認・一括実行」の薄いオーケストレーターとして強化する。Discord 側は `src/bot.js` の既存 slash command 入口に合わせて、dry-run 表示と apply 制限の案内をスマホで読める短さに整える。
+
+**Tech Stack:** Node.js 20+, CommonJS, npm scripts, Discord.js, Notion API, GitHub REST API.
+
+---
+
+## Scope
+
+この計画で扱うもの:
+
+- `npm run bootstrap:project` の生成物確認
+- `npm run apply:bootstrap` の dry-run / apply 前確認
+- spec / issue seeds のファイル指定ルール
+- Discord の `/codex-apply-bootstrap` 表示と安全導線
+- ドキュメント更新
+- `context.md` の引き継ぎ更新
+
+この計画で扱わないもの:
+
+- Notion DB スキーマ自体の変更
+- GitHub Actions 化
+- ComfyUI 連携
+- Web ダッシュボード
+- note 下書き生成
+
+## File Structure
+
+変更候補:
+
+- Modify: `src/apply-bootstrap-project.js`
+  - `--title` とファイル指定から成果物を解決する入口。
+  - dry-run / apply の表示と事前チェックを強化する。
+- Modify: `src/create-notion-spec-from-draft.js`
+  - dry-run 表示で Notion に作られる Spec の要点を読みやすくする。
+- Modify: `src/create-github-issues-from-seeds.js`
+  - dry-run 表示で作成予定 Issue のタイトル、ラベル、本文冒頭を一覧化する。
+- Modify: `src/bot.js`
+  - `/codex-apply-bootstrap` の返信文を短くし、dry-run と本実行の違いを明確にする。
+- Modify: `src/register-commands.js`
+  - slash command の説明文と option 説明を実運用向けに揃える。
+- Modify: `docs/project-bootstrap-flow.md`
+  - 生成手順と成果物の確認方法を更新する。
+- Modify: `docs/project-bootstrap-apply-flow.md`
+  - dry-run、本実行、ファイル指定、失敗時の見方を更新する。
+- Modify: `docs/discord-bot-reference.md`
+  - Discord からの操作手順を更新する。
+- Modify: `docs/discord-bot-setup.md`
+  - apply 許可チャンネルと環境変数の説明を更新する。
+- Modify: `README.md`
+  - 主要導線だけ短く反映する。
+- Modify: `context.md`
+  - `Immediate Next Steps` と `Handoff` を実装結果に合わせて更新する。
+
+検証で使うコマンド:
+
+```powershell
+node --check src/apply-bootstrap-project.js
+node --check src/create-notion-spec-from-draft.js
+node --check src/create-github-issues-from-seeds.js
+node --check src/bot.js
+node --check src/register-commands.js
+npm run bootstrap:project -- --title "Bootstrap Resolution Sample"
+npm run apply:bootstrap -- --title "Bootstrap Resolution Sample"
+npm run apply:bootstrap -- --specFile 20260425-bootstrap-resolution-sample-spec.md --issueSeedFile 20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+注意:
+
+- `bootstrap:project` は `drafts/` に Markdown を生成する。
+- 検証で生成したサンプル成果物を残すか消すかは、実装セッション開始時に決める。
+- `.env` の秘密値は読まない。必要なキー名は `.env.example` とエラーメッセージで確認する。
+
+---
+
+### Task 1: Baseline Verification
+
+**Files:**
+
+- Read: `package.json`
+- Read: `src/apply-bootstrap-project.js`
+- Read: `src/create-notion-spec-from-draft.js`
+- Read: `src/create-github-issues-from-seeds.js`
+- Read: `src/bot.js`
+- Read: `src/register-commands.js`
+
+- [ ] **Step 1: 現在の git 状態を確認する**
+
+Run:
+
+```powershell
+git status --short
+```
+
+Expected:
+
+```text
+README.md, context.md, docs/*, src/* に既存変更がある場合は、ユーザー変更として扱い、勝手に戻さない。
+```
+
+- [ ] **Step 2: 主要スクリプトの構文確認をする**
+
+Run:
+
+```powershell
+node --check src/apply-bootstrap-project.js
+node --check src/create-notion-spec-from-draft.js
+node --check src/create-github-issues-from-seeds.js
+node --check src/bot.js
+node --check src/register-commands.js
+```
+
+Expected:
+
+```text
+各コマンドが何も出さず exit code 0 で終了する。
+```
+
+- [ ] **Step 3: help 出力を確認する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --help
+```
+
+Expected:
+
+```text
+Usage:
+  npm run apply:bootstrap -- --title "Project Name" [--apply]
+  npm run apply:bootstrap -- --specFile 20260424-project-name-spec.md --issueSeedFile 20260424-project-name-issue-seeds.md [--apply]
+Default mode is dry-run.
+```
+
+- [ ] **Step 4: 生成物がない状態のエラーを確認する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --title "Definitely Missing Bootstrap Sample"
+```
+
+Expected:
+
+```text
+No generated file found for "Definitely Missing Bootstrap Sample" ...
+Usage:
+  npm run apply:bootstrap ...
+```
+
+### Task 2: CLI Option Aliases And Artifact Resolution
+
+**Files:**
+
+- Modify: `src/apply-bootstrap-project.js`
+- Verify: `node --check src/apply-bootstrap-project.js`
+
+- [ ] **Step 1: `parseArgs` の結果を正規化する helper を追加する**
+
+Add near the existing `requireValue` function:
+
+```js
+function firstValue(args, keys) {
+  for (const key of keys) {
+    const value = args[key];
+    if (value && value !== "true") {
+      return value.trim();
+    }
+  }
+
+  return "";
+}
+```
+
+- [ ] **Step 2: `resolveBootstrapArtifacts` で alias を受ける**
+
+Replace the first lines of `resolveBootstrapArtifacts(args)` with:
+
+```js
+function resolveBootstrapArtifacts(args) {
+  const title = firstValue(args, ["title"]);
+  const specFile = firstValue(args, ["specFile", "spec_file", "spec-file"]);
+  const issueSeedFile = firstValue(args, [
+    "issueSeedFile",
+    "issue_seed_file",
+    "issue-seed-file",
+  ]);
+  const hasSpecFile = Boolean(specFile);
+  const hasIssueSeedFile = Boolean(issueSeedFile);
+```
+
+Then replace later references:
+
+```js
+specPath: resolveExistingFile(SPECS_DIR, specFile, "Spec"),
+issueSeedPath: resolveExistingFile(ISSUE_SEEDS_DIR, issueSeedFile, "Issue seed"),
+```
+
+and:
+
+```js
+? resolveExistingFile(SPECS_DIR, specFile, "Spec")
+```
+
+```js
+? resolveExistingFile(ISSUE_SEEDS_DIR, issueSeedFile, "Issue seed")
+```
+
+- [ ] **Step 3: help に alias を明記する**
+
+Update `printUsage()` so the specific file form includes both camelCase and Discord-style names:
+
+```text
+  npm run apply:bootstrap -- --specFile 20260424-project-name-spec.md --issueSeedFile 20260424-project-name-issue-seeds.md [--apply]
+  npm run apply:bootstrap -- --spec_file 20260424-project-name-spec.md --issue_seed_file 20260424-project-name-issue-seeds.md [--apply]
+```
+
+- [ ] **Step 4: 構文確認をする**
+
+Run:
+
+```powershell
+node --check src/apply-bootstrap-project.js
+```
+
+Expected:
+
+```text
+何も出さず exit code 0。
+```
+
+### Task 3: Apply Bootstrap Preflight Summary
+
+**Files:**
+
+- Modify: `src/apply-bootstrap-project.js`
+- Verify: `node --check src/apply-bootstrap-project.js`
+
+- [ ] **Step 1: `relativePath` helper を追加する**
+
+Add after `runNodeScript`:
+
+```js
+function relativePath(filePath) {
+  return path.relative(ROOT_DIR, filePath) || filePath;
+}
+```
+
+- [ ] **Step 2: apply 実行時の環境変数チェックを追加する**
+
+Add after `relativePath`:
+
+```js
+function validateApplyEnvironment() {
+  const missing = [];
+
+  if (!process.env.NOTION_API_TOKEN) {
+    missing.push("NOTION_API_TOKEN");
+  }
+
+  if (!process.env.GITHUB_TOKEN) {
+    missing.push("GITHUB_TOKEN");
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables for --apply: ${missing.join(", ")}`
+    );
+  }
+}
+```
+
+- [ ] **Step 3: `dotenv` を読み込む**
+
+At the top of `src/apply-bootstrap-project.js`, add:
+
+```js
+require("dotenv").config();
+```
+
+- [ ] **Step 4: `main()` で本実行前に環境変数を検証する**
+
+After:
+
+```js
+const apply = args.apply === "true";
+```
+
+Add:
+
+```js
+if (apply) {
+  validateApplyEnvironment();
+}
+```
+
+- [ ] **Step 5: dry-run / apply の事前サマリを出す**
+
+Before running `create-notion-spec-from-draft.js`, add:
+
+```js
+console.log(apply ? "Bootstrap apply preflight." : "Bootstrap dry-run preflight.");
+console.log("");
+console.log(`- mode: ${apply ? "apply" : "dry-run"}`);
+console.log(`- spec file: ${relativePath(specPath)}`);
+console.log(`- issue seeds file: ${relativePath(issueSeedPath)}`);
+console.log("");
+```
+
+- [ ] **Step 6: 既存の `path.relative` 表示を helper に統一する**
+
+Replace:
+
+```js
+path.relative(ROOT_DIR, specPath)
+path.relative(ROOT_DIR, issueSeedPath)
+```
+
+with:
+
+```js
+relativePath(specPath)
+relativePath(issueSeedPath)
+```
+
+- [ ] **Step 7: 構文確認をする**
+
+Run:
+
+```powershell
+node --check src/apply-bootstrap-project.js
+```
+
+Expected:
+
+```text
+何も出さず exit code 0。
+```
+
+### Task 4: Notion Spec Dry-Run Preview
+
+**Files:**
+
+- Modify: `src/create-notion-spec-from-draft.js`
+- Verify: `node --check src/create-notion-spec-from-draft.js`
+
+- [ ] **Step 1: dry-run 出力の現在形を確認する**
+
+Run:
+
+```powershell
+npm run create:notion-spec -- --help
+```
+
+Expected:
+
+```text
+spec draft から Notion Specs page を作るための使い方が表示される。
+```
+
+- [ ] **Step 2: dry-run 出力に title / source file / body preview を含める**
+
+Modify the dry-run branch so it prints this shape:
+
+```text
+[dry-run] create Notion spec
+- title: <parsed title>
+- source file: drafts/specs/<file>
+- database: Specs
+- body preview:
+  <first non-empty lines>
+```
+
+Implementation rule:
+
+```js
+const previewLines = markdown
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .slice(0, 8);
+```
+
+- [ ] **Step 3: apply 時の成功出力を短くする**
+
+Ensure successful apply prints:
+
+```text
+created Notion spec: <title>
+<notion page url if available>
+```
+
+- [ ] **Step 4: 構文確認をする**
+
+Run:
+
+```powershell
+node --check src/create-notion-spec-from-draft.js
+```
+
+Expected:
+
+```text
+何も出さず exit code 0。
+```
+
+### Task 5: GitHub Issue Seeds Dry-Run Preview
+
+**Files:**
+
+- Modify: `src/create-github-issues-from-seeds.js`
+- Verify: `node --check src/create-github-issues-from-seeds.js`
+
+- [ ] **Step 1: dry-run 出力の現在形を確認する**
+
+Run:
+
+```powershell
+npm run create:github-issues -- --help
+```
+
+Expected:
+
+```text
+Issue seed Markdown から GitHub Issue を作るための使い方が表示される。
+```
+
+- [ ] **Step 2: dry-run 出力を Issue 単位の一覧にする**
+
+Dry-run output should follow this shape:
+
+```text
+[dry-run] create GitHub issues from drafts/issue-seeds/<file>
+- #1 <title>
+  labels: <comma separated labels or none>
+  body: <first 160 characters>
+- #2 <title>
+  labels: <comma separated labels or none>
+  body: <first 160 characters>
+```
+
+Implementation rule for body preview:
+
+```js
+function previewText(value, maxLength = 160) {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) {
+    return compact;
+  }
+
+  return `${compact.slice(0, maxLength - 3)}...`;
+}
+```
+
+- [ ] **Step 3: apply 時の成功出力を Issue URL 一覧にする**
+
+Apply output should follow this shape:
+
+```text
+created GitHub issues
+- #12 <title> <url>
+- #13 <title> <url>
+```
+
+- [ ] **Step 4: 構文確認をする**
+
+Run:
+
+```powershell
+node --check src/create-github-issues-from-seeds.js
+```
+
+Expected:
+
+```text
+何も出さず exit code 0。
+```
+
+### Task 6: Discord Apply Bootstrap Response
+
+**Files:**
+
+- Modify: `src/bot.js`
+- Modify: `src/register-commands.js`
+- Verify: `node --check src/bot.js`
+- Verify: `node --check src/register-commands.js`
+
+- [ ] **Step 1: `/codex-apply-bootstrap` の handler を確認する**
+
+Run:
+
+```powershell
+Select-String -Path src\bot.js -Pattern 'handleBootstrapApply|codex-apply-bootstrap|canApplyBootstrapArtifacts' -Context 0,20
+```
+
+Expected:
+
+```text
+dry_run:false の許可チェック、option 取得、子プロセス実行箇所が見つかる。
+```
+
+- [ ] **Step 2: Discord 返信の見出しを短くする**
+
+For dry-run success, response should start with:
+
+```text
+Bootstrap dry-run completed.
+```
+
+For apply success, response should start with:
+
+```text
+Bootstrap apply completed.
+```
+
+For blocked apply, response should include:
+
+```text
+This channel cannot run dry_run:false.
+Run dry_run:true first, or use an allowed apply channel.
+```
+
+- [ ] **Step 3: 長い出力は既存の切り詰め helper を使う**
+
+Use the repository's existing Discord output truncation helper in `src/bot.js`. If the helper name is not obvious, search:
+
+```powershell
+Select-String -Path src\bot.js -Pattern 'truncate|slice|2000|MAX' -Context 0,4
+```
+
+The final message must fit in Discord's message limit and keep the preflight lines visible.
+
+- [ ] **Step 4: slash command option description を揃える**
+
+In `src/register-commands.js`, ensure `/codex-apply-bootstrap` descriptions communicate:
+
+```text
+title: 企画タイトル。最新の spec / issue seeds を自動解決する
+spec_file: drafts/specs 配下の spec ファイル名
+issue_seed_file: drafts/issue-seeds 配下の issue seeds ファイル名
+dry_run: true なら確認のみ、false なら Notion / GitHub に反映
+```
+
+- [ ] **Step 5: 構文確認をする**
+
+Run:
+
+```powershell
+node --check src/bot.js
+node --check src/register-commands.js
+```
+
+Expected:
+
+```text
+各コマンドが何も出さず exit code 0 で終了する。
+```
+
+### Task 7: End-To-End Dry-Run Verification
+
+**Files:**
+
+- Generated: `drafts/proposals/20260425-bootstrap-resolution-sample.md`
+- Generated: `drafts/specs/20260425-bootstrap-resolution-sample-spec.md`
+- Generated: `drafts/issue-seeds/20260425-bootstrap-resolution-sample-issue-seeds.md`
+
+- [ ] **Step 1: サンプル企画を生成する**
+
+Run:
+
+```powershell
+npm run bootstrap:project -- --title "Bootstrap Resolution Sample" --genre "Operations Test" --platform "PC" --audience "Solo developer" --coreHook "Verify bootstrap flow" --mode "Single player"
+```
+
+Expected:
+
+```text
+Project bootstrap completed.
+- proposal: drafts/proposals/20260425-bootstrap-resolution-sample.md
+- spec: drafts/specs/20260425-bootstrap-resolution-sample-spec.md
+- issue seeds: drafts/issue-seeds/20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+- [ ] **Step 2: title 指定で dry-run する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --title "Bootstrap Resolution Sample"
+```
+
+Expected:
+
+```text
+Bootstrap dry-run preflight.
+- mode: dry-run
+- spec file: drafts/specs/20260425-bootstrap-resolution-sample-spec.md
+- issue seeds file: drafts/issue-seeds/20260425-bootstrap-resolution-sample-issue-seeds.md
+[Notion Specs]
+[dry-run] create Notion spec
+[GitHub Issues]
+[dry-run] create GitHub issues
+```
+
+- [ ] **Step 3: camelCase ファイル指定で dry-run する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --specFile 20260425-bootstrap-resolution-sample-spec.md --issueSeedFile 20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+Expected:
+
+```text
+Bootstrap dry-run preflight.
+- mode: dry-run
+- spec file: drafts/specs/20260425-bootstrap-resolution-sample-spec.md
+- issue seeds file: drafts/issue-seeds/20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+- [ ] **Step 4: snake_case ファイル指定で dry-run する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --spec_file 20260425-bootstrap-resolution-sample-spec.md --issue_seed_file 20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+Expected:
+
+```text
+Bootstrap dry-run preflight.
+- mode: dry-run
+- spec file: drafts/specs/20260425-bootstrap-resolution-sample-spec.md
+- issue seeds file: drafts/issue-seeds/20260425-bootstrap-resolution-sample-issue-seeds.md
+```
+
+- [ ] **Step 5: apply の環境変数不足エラーを確認する**
+
+Run in an environment without tokens:
+
+```powershell
+npm run apply:bootstrap -- --title "Bootstrap Resolution Sample" --apply
+```
+
+Expected:
+
+```text
+Missing required environment variables for --apply: NOTION_API_TOKEN, GITHUB_TOKEN
+```
+
+If one token is present, only the missing token appears.
+
+### Task 8: Documentation Update
+
+**Files:**
+
+- Modify: `docs/project-bootstrap-flow.md`
+- Modify: `docs/project-bootstrap-apply-flow.md`
+- Modify: `docs/discord-bot-reference.md`
+- Modify: `docs/discord-bot-setup.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: `docs/project-bootstrap-flow.md` に運用順を明記する**
+
+Add this workflow:
+
+```markdown
+## Recommended Operation
+
+1. `npm run bootstrap:project -- --title "Project Name"` で下書きを生成する
+2. `drafts/proposals/` の proposal を確認する
+3. `drafts/specs/` の spec draft を確認する
+4. `drafts/issue-seeds/` の Issue seeds を確認する
+5. `npm run apply:bootstrap -- --title "Project Name"` で dry-run する
+6. dry-run の Notion / GitHub preview を確認する
+7. 問題がなければ `npm run apply:bootstrap -- --title "Project Name" --apply` を実行する
+```
+
+- [ ] **Step 2: `docs/project-bootstrap-apply-flow.md` にファイル指定ルールを明記する**
+
+Include:
+
+```markdown
+## File Resolution Rule
+
+- `--title` のみ指定した場合は、タイトル slug に一致する最新の spec / issue seeds を使う
+- `--specFile` と `--issueSeedFile` を指定した場合は、そのファイルを使う
+- CLI では `--spec_file` と `--issue_seed_file` も同じ意味で使える
+- Discord では `spec_file` と `issue_seed_file` を使う
+```
+
+- [ ] **Step 3: Discord docs に apply 制限を書く**
+
+In `docs/discord-bot-reference.md`, under `/codex-apply-bootstrap`, include:
+
+```markdown
+制限:
+
+- 指定なしでは `dry_run:true`
+- `dry_run:false` は `DISCORD_NOTION_APPLY_CHANNEL_IDS` と `DISCORD_ISSUE_APPLY_CHANNEL_IDS` の条件を満たすチャンネルでのみ使う
+- 本実行前に dry-run の preview を確認する
+```
+
+- [ ] **Step 4: README の Discord MVP コマンド説明を短く更新する**
+
+Add a short bootstrap operation block:
+
+```markdown
+Bootstrap flow:
+
+```bash
+npm run bootstrap:project -- --title "Project Name"
+npm run apply:bootstrap -- --title "Project Name"
+npm run apply:bootstrap -- --title "Project Name" --apply
+```
+```
+
+- [ ] **Step 5: markdown の読み崩れを確認する**
+
+Run:
+
+```powershell
+Select-String -Path README.md,docs\project-bootstrap-flow.md,docs\project-bootstrap-apply-flow.md,docs\discord-bot-reference.md,docs\discord-bot-setup.md -Pattern 'TODO|TBD'
+```
+
+Expected:
+
+```text
+今回追加した箇所に TODO / TBD がない。
+```
+
+### Task 9: Context Update And Final Verification
+
+**Files:**
+
+- Modify: `context.md`
+
+- [ ] **Step 1: `context.md` の Completed Items を更新する**
+
+Add one concise bullet:
+
+```markdown
+- bootstrap から Notion / GitHub 反映までの dry-run 表示、ファイル指定 alias、実運用手順を整理済み
+```
+
+- [ ] **Step 2: `Immediate Next Steps` を更新する**
+
+Replace the bootstrap-focused items with:
+
+```markdown
+1. サンプル企画で `bootstrap:project` から `apply:bootstrap --apply` までを実環境で 1 サイクル検証する
+2. Discord から `/codex-bootstrap-project` と `/codex-apply-bootstrap` の dry-run を実行してスマホ表示を確認する
+3. GitHub Issue 作成後に `sync:tasks:dry` を実行し、Notion `Tasks` 同期結果を確認する
+4. 企画テンプレートの genre / platform / audience 入力項目を実運用に合わせて拡張する
+```
+
+- [ ] **Step 3: `Handoff` を更新する**
+
+Add:
+
+```markdown
+- `apply:bootstrap` は title 指定、camelCase ファイル指定、snake_case ファイル指定で dry-run できる
+- 本実行前に Notion / GitHub の作成予定内容を preview で確認する運用にした
+```
+
+- [ ] **Step 4: 最終構文確認をする**
+
+Run:
+
+```powershell
+node --check src/apply-bootstrap-project.js
+node --check src/create-notion-spec-from-draft.js
+node --check src/create-github-issues-from-seeds.js
+node --check src/bot.js
+node --check src/register-commands.js
+```
+
+Expected:
+
+```text
+各コマンドが何も出さず exit code 0 で終了する。
+```
+
+- [ ] **Step 5: 最終 dry-run を実行する**
+
+Run:
+
+```powershell
+npm run apply:bootstrap -- --title "Bootstrap Resolution Sample"
+```
+
+Expected:
+
+```text
+Bootstrap dry-run preflight.
+[Notion Specs]
+[dry-run] create Notion spec
+[GitHub Issues]
+[dry-run] create GitHub issues
+```
+
+- [ ] **Step 6: 差分を確認する**
+
+Run:
+
+```powershell
+git status --short
+git diff -- README.md context.md docs/project-bootstrap-flow.md docs/project-bootstrap-apply-flow.md docs/discord-bot-reference.md docs/discord-bot-setup.md src/apply-bootstrap-project.js src/create-notion-spec-from-draft.js src/create-github-issues-from-seeds.js src/bot.js src/register-commands.js
+```
+
+Expected:
+
+```text
+Bootstrap 実運用固定に関係する差分だけが出る。
+秘密値や .env の中身は差分に含まれない。
+```
+
+---
+
+## Commit Plan
+
+実装時は、以下の小さなコミットに分ける。
+
+1. `feat: improve bootstrap apply resolution`
+   - `src/apply-bootstrap-project.js`
+2. `feat: improve bootstrap dry-run previews`
+   - `src/create-notion-spec-from-draft.js`
+   - `src/create-github-issues-from-seeds.js`
+3. `feat: refine discord bootstrap apply flow`
+   - `src/bot.js`
+   - `src/register-commands.js`
+4. `docs: document bootstrap operation flow`
+   - `README.md`
+   - `docs/project-bootstrap-flow.md`
+   - `docs/project-bootstrap-apply-flow.md`
+   - `docs/discord-bot-reference.md`
+   - `docs/discord-bot-setup.md`
+   - `context.md`
+
+## Self-Review
+
+- Spec coverage: Bootstrap 生成、成果物解決、dry-run preview、Discord 操作、docs、context 更新を各 Task に含めた。
+- Placeholder scan: `TODO` / `TBD` は計画本文に含めていない。
+- Type consistency: CLI option は `specFile` / `issueSeedFile` / `spec_file` / `issue_seed_file` / `spec-file` / `issue-seed-file` に統一した。
+- Scope check: Notion DB 変更、ComfyUI、Web dashboard は除外し、Bootstrap 実運用固定に限定した。

--- a/src/apply-bootstrap-project.js
+++ b/src/apply-bootstrap-project.js
@@ -1,8 +1,11 @@
 const path = require("path");
 const { spawnSync } = require("child_process");
+require("dotenv").config();
 
 const ROOT_DIR = path.resolve(__dirname, "..");
 const NODE_BIN = process.execPath;
+const SPECS_DIR = path.resolve(ROOT_DIR, "drafts", "specs");
+const ISSUE_SEEDS_DIR = path.resolve(ROOT_DIR, "drafts", "issue-seeds");
 
 function parseArgs(argv) {
   const args = {};
@@ -35,6 +38,17 @@ function requireValue(args, key) {
   return value.trim();
 }
 
+function firstValue(args, keys) {
+  for (const key of keys) {
+    const value = args[key];
+    if (value && value !== "true") {
+      return value.trim();
+    }
+  }
+
+  return "";
+}
+
 function slugify(text) {
   return text
     .toLowerCase()
@@ -45,12 +59,80 @@ function slugify(text) {
     .replace(/^-+|-+$/g, "");
 }
 
-function todayStamp() {
-  const now = new Date();
-  const yyyy = String(now.getFullYear());
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  return `${yyyy}${mm}${dd}`;
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveExistingFile(dirPath, input, label) {
+  const directPath = path.resolve(process.cwd(), input);
+  if (path.isAbsolute(input) && path.isAbsolute(directPath) && require("fs").existsSync(directPath)) {
+    return directPath;
+  }
+
+  if (require("fs").existsSync(directPath)) {
+    return directPath;
+  }
+
+  const localPath = path.join(dirPath, input);
+  if (require("fs").existsSync(localPath)) {
+    return localPath;
+  }
+
+  throw new Error(`${label} file not found: ${input}`);
+}
+
+function findLatestGeneratedFile(dirPath, title, suffix) {
+  const fs = require("fs");
+  const slug = slugify(title);
+  const pattern = new RegExp(`^\\d{8}-${escapeRegExp(slug)}${escapeRegExp(suffix)}\\.md$`, "i");
+
+  const matchingFiles = fs
+    .readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && pattern.test(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => b.localeCompare(a));
+
+  if (matchingFiles.length === 0) {
+    throw new Error(
+      `No generated file found for "${title}" in ${path.relative(ROOT_DIR, dirPath)} matching *-${slug}${suffix}.md`
+    );
+  }
+
+  return path.join(dirPath, matchingFiles[0]);
+}
+
+function resolveBootstrapArtifacts(args) {
+  const title = firstValue(args, ["title"]);
+  const specFile = firstValue(args, ["specFile", "spec_file", "spec-file"]);
+  const issueSeedFile = firstValue(args, [
+    "issueSeedFile",
+    "issue_seed_file",
+    "issue-seed-file",
+  ]);
+  const hasSpecFile = Boolean(specFile);
+  const hasIssueSeedFile = Boolean(issueSeedFile);
+
+  if (hasSpecFile && hasIssueSeedFile) {
+    return {
+      specPath: resolveExistingFile(SPECS_DIR, specFile, "Spec"),
+      issueSeedPath: resolveExistingFile(ISSUE_SEEDS_DIR, issueSeedFile, "Issue seed"),
+    };
+  }
+
+  if (!title) {
+    throw new Error(
+      "--title is required unless both --specFile and --issueSeedFile are provided"
+    );
+  }
+
+  return {
+    specPath: hasSpecFile
+      ? resolveExistingFile(SPECS_DIR, specFile, "Spec")
+      : findLatestGeneratedFile(SPECS_DIR, title, "-spec"),
+    issueSeedPath: hasIssueSeedFile
+      ? resolveExistingFile(ISSUE_SEEDS_DIR, issueSeedFile, "Issue seed")
+      : findLatestGeneratedFile(ISSUE_SEEDS_DIR, title, "-issue-seeds"),
+  };
 }
 
 function runNodeScript(scriptPath, args) {
@@ -68,13 +150,39 @@ function runNodeScript(scriptPath, args) {
   return result.stdout.trim();
 }
 
+function relativePath(filePath) {
+  return path.relative(ROOT_DIR, filePath) || filePath;
+}
+
+function validateApplyEnvironment() {
+  const missing = [];
+
+  if (!process.env.NOTION_API_TOKEN) {
+    missing.push("NOTION_API_TOKEN");
+  }
+
+  if (!process.env.GITHUB_TOKEN) {
+    missing.push("GITHUB_TOKEN");
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables for --apply: ${missing.join(", ")}`
+    );
+  }
+}
+
 function printUsage() {
   console.log(
     [
       "Usage:",
       "  npm run apply:bootstrap -- --title \"Project Name\" [--apply]",
+      "  npm run apply:bootstrap -- --specFile 20260424-project-name-spec.md --issueSeedFile 20260424-project-name-issue-seeds.md [--apply]",
+      "  npm run apply:bootstrap -- --spec_file 20260424-project-name-spec.md --issue_seed_file 20260424-project-name-issue-seeds.md [--apply]",
       "",
       "Default mode is dry-run.",
+      "",
+      "If only --title is given, the latest matching generated files are used.",
       "",
       "This command expects these generated files to already exist:",
       "- drafts/specs/YYYYMMDD-project-name-spec.md",
@@ -91,19 +199,27 @@ function main() {
     return;
   }
 
-  const title = requireValue(args, "title");
-  const baseName = `${todayStamp()}-${slugify(title)}`;
-  const specFile = `${baseName}-spec.md`;
-  const issueSeedFile = `${baseName}-issue-seeds.md`;
   const apply = args.apply === "true";
+  const { specPath, issueSeedPath } = resolveBootstrapArtifacts(args);
 
-  const notionArgs = ["--file", specFile];
-  const githubArgs = ["--file", issueSeedFile];
+  if (apply) {
+    validateApplyEnvironment();
+  }
+
+  const notionArgs = ["--file", specPath];
+  const githubArgs = ["--file", issueSeedPath];
 
   if (apply) {
     notionArgs.push("--apply");
     githubArgs.push("--apply");
   }
+
+  console.log(apply ? "Bootstrap apply preflight." : "Bootstrap dry-run preflight.");
+  console.log("");
+  console.log(`- mode: ${apply ? "apply" : "dry-run"}`);
+  console.log(`- spec file: ${relativePath(specPath)}`);
+  console.log(`- issue seeds file: ${relativePath(issueSeedPath)}`);
+  console.log("");
 
   const notionOutput = runNodeScript(
     path.resolve(__dirname, "create-notion-spec-from-draft.js"),
@@ -115,6 +231,9 @@ function main() {
   );
 
   console.log(apply ? "Bootstrap apply completed." : "Bootstrap dry-run completed.");
+  console.log("");
+  console.log(`- spec file: ${relativePath(specPath)}`);
+  console.log(`- issue seeds file: ${relativePath(issueSeedPath)}`);
   console.log("");
   console.log(`[Notion Specs]`);
   console.log(notionOutput);

--- a/src/bot.js
+++ b/src/bot.js
@@ -190,6 +190,82 @@ function trimForDiscord(text) {
   return `${text.slice(0, MAX_DISCORD_MESSAGE - 40)}\n\n[truncated]`;
 }
 
+function getOutputValue(output, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = output.match(new RegExp(`^- ${escaped}:\\s*(.+)$`, "im"));
+  return match ? match[1].trim() : "";
+}
+
+function stripIssuePrefix(title) {
+  return title.replace(/^[^:]+:\s*/, "").trim();
+}
+
+function extractIssueTitles(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) => line.match(/^- #\d+\s+(.+?)(?:\s+https?:\/\/\S+)?$/))
+    .filter(Boolean)
+    .map((match) => stripIssuePrefix(match[1]));
+}
+
+function buildBootstrapDiscordSummary(output) {
+  const proposal = getOutputValue(output, "proposal");
+  const spec = getOutputValue(output, "spec");
+  const issueSeeds = getOutputValue(output, "issue seeds");
+
+  return trimForDiscord(
+    [
+      "ブートストラップが完了しました。",
+      "",
+      "生成ファイル:",
+      proposal ? `- 企画書: ${proposal}` : null,
+      spec ? `- Spec: ${spec}` : null,
+      issueSeeds ? `- Issue下書き: ${issueSeeds}` : null,
+      "",
+      "次は内容を確認してから、`/codex-apply-bootstrap` で反映前チェックをしてください。",
+    ]
+      .filter((line) => line !== null)
+      .join("\n")
+  );
+}
+
+function buildBootstrapApplyDiscordSummary(output, dryRun) {
+  const specFile = getOutputValue(output, "spec file");
+  const issueSeedsFile = getOutputValue(output, "issue seeds file");
+  const notionTitleMatch = output.match(/^- title:\s*(.+)$/im) || output.match(/^created Notion spec:\s*(.+)$/im);
+  const notionTitle = notionTitleMatch ? notionTitleMatch[1].trim() : "";
+  const notionUrlMatch = output.match(/^https?:\/\/www\.notion\.so\/\S+$/im);
+  const notionUrl = notionUrlMatch ? notionUrlMatch[0].trim() : "";
+  const issueTitles = extractIssueTitles(output);
+
+  const lines = [
+    dryRun ? "反映前チェックが完了しました。" : "反映が完了しました。",
+    "",
+    `モード: ${dryRun ? "確認のみ" : "本実行"}`,
+    specFile ? `Spec: ${specFile}` : null,
+    issueSeedsFile ? `Issue下書き: ${issueSeedsFile}` : null,
+    "",
+    "Notion:",
+    notionTitle ? `- ${dryRun ? "作成予定" : "作成済み"}: ${notionTitle}` : "- 対象を確認しました",
+    notionUrl ? `- ${notionUrl}` : null,
+    "",
+    "GitHub:",
+    `- ${dryRun ? "作成予定 Issue" : "作成済み Issue"}: ${issueTitles.length}件`,
+    ...issueTitles.slice(0, 8).map((title) => `  - ${title}`),
+  ].filter((line) => line !== null);
+
+  if (issueTitles.length > 8) {
+    lines.push(`  - 他 ${issueTitles.length - 8}件`);
+  }
+
+  if (dryRun) {
+    lines.push("", "問題なければ `dry_run:false` で本実行できます。");
+  }
+
+  return trimForDiscord(lines.join("\n"));
+}
+
 function normalizeInstruction(text) {
   return text.trim();
 }
@@ -577,11 +653,10 @@ function canApplyBootstrapArtifacts(interaction) {
 
 function buildBootstrapApplyDeniedReply(reason) {
   return [
-    "bootstrap 後の本反映はこの条件では許可されていません。",
+    "This channel cannot run dry_run:false.",
+    "Run dry_run:true first, or use an allowed apply channel.",
     "",
     reason,
-    "",
-    "まずは `dry_run:true` で確認してください。",
   ].join("\n");
 }
 
@@ -721,6 +796,27 @@ function collectBootstrapArgs(interaction) {
   return args;
 }
 
+function collectBootstrapApplyArgs(interaction) {
+  const title = interaction.options.getString("title");
+  const specFile = interaction.options.getString("spec_file");
+  const issueSeedFile = interaction.options.getString("issue_seed_file");
+  const args = [];
+
+  if (title) {
+    args.push("--title", title);
+  }
+
+  if (specFile) {
+    args.push("--specFile", specFile);
+  }
+
+  if (issueSeedFile) {
+    args.push("--issueSeedFile", issueSeedFile);
+  }
+
+  return args;
+}
+
 async function handleProposalGeneration(interaction) {
   await interaction.deferReply({ ephemeral: REPLY_EPHEMERAL });
   const title = interaction.options.getString("title", true);
@@ -804,19 +900,7 @@ async function handleProjectBootstrap(interaction) {
       resultPreview: trimForDiscord(output),
     });
 
-    await interaction.editReply(
-      trimForDiscord(
-        [
-          "新規企画のブートストラップが完了しました。",
-          "",
-          "```",
-          output,
-          "```",
-          "",
-          "次は proposal / spec / issue seeds を順に確認してください。",
-        ].join("\n")
-      )
-    );
+    await interaction.editReply(buildBootstrapDiscordSummary(output));
   } catch (error) {
     appendCommandLog({
       event: "project_bootstrap_failed",
@@ -841,8 +925,18 @@ async function handleProjectBootstrap(interaction) {
 
 async function handleBootstrapApply(interaction, dryRun) {
   await interaction.deferReply({ ephemeral: REPLY_EPHEMERAL });
-  const title = interaction.options.getString("title", true);
-  const args = ["--title", title];
+  const title = interaction.options.getString("title") || "(explicit files)";
+  const specFile = interaction.options.getString("spec_file");
+  const issueSeedFile = interaction.options.getString("issue_seed_file");
+
+  if (!interaction.options.getString("title") && !(specFile && issueSeedFile)) {
+    await interaction.editReply(
+      "title を指定するか、spec_file と issue_seed_file の両方を指定してください。"
+    );
+    return;
+  }
+
+  const args = collectBootstrapApplyArgs(interaction);
   if (!dryRun) {
     args.push("--apply");
   }
@@ -853,6 +947,8 @@ async function handleBootstrapApply(interaction, dryRun) {
     userTag: interaction.user.tag,
     channelId: interaction.channelId,
     title,
+    specFile,
+    issueSeedFile,
     dryRun,
   });
 
@@ -864,21 +960,13 @@ async function handleBootstrapApply(interaction, dryRun) {
       userTag: interaction.user.tag,
       channelId: interaction.channelId,
       title,
+      specFile,
+      issueSeedFile,
       dryRun,
       resultPreview: trimForDiscord(output),
     });
 
-    await interaction.editReply(
-      trimForDiscord(
-        [
-          dryRun ? "bootstrap 反映 dry-run が完了しました。" : "bootstrap 反映が完了しました。",
-          "",
-          "```",
-          output,
-          "```",
-        ].join("\n")
-      )
-    );
+    await interaction.editReply(buildBootstrapApplyDiscordSummary(output, dryRun));
   } catch (error) {
     appendCommandLog({
       event: "bootstrap_apply_failed",
@@ -886,6 +974,8 @@ async function handleBootstrapApply(interaction, dryRun) {
       userTag: interaction.user.tag,
       channelId: interaction.channelId,
       title,
+      specFile,
+      issueSeedFile,
       dryRun,
       error: error.message,
     });
@@ -1434,13 +1524,25 @@ const commands = [
     .addStringOption((option) =>
       option
         .setName("title")
-        .setDescription("企画タイトル")
-        .setRequired(true)
+        .setDescription("企画タイトル。最新の spec / issue seeds を自動解決する")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("spec_file")
+        .setDescription("drafts/specs 配下の spec ファイル名")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("issue_seed_file")
+        .setDescription("drafts/issue-seeds 配下の issue seeds ファイル名")
+        .setRequired(false)
     )
     .addBooleanOption((option) =>
       option
         .setName("dry_run")
-        .setDescription("反映はせず確認だけ行う")
+        .setDescription("true は確認のみ、false は Notion / GitHub に反映")
         .setRequired(false)
     ),
   new SlashCommandBuilder()

--- a/src/create-github-issues-from-seeds.js
+++ b/src/create-github-issues-from-seeds.js
@@ -4,6 +4,7 @@ const dotenv = require("dotenv");
 
 dotenv.config();
 
+const ROOT_DIR = path.resolve(__dirname, "..");
 const STATUS_SOURCES_PATH = path.resolve(__dirname, "..", "config", "status-sources.json");
 const ISSUE_SEEDS_DIR = path.resolve(__dirname, "..", "drafts", "issue-seeds");
 const DRY_RUN = !process.argv.includes("--apply");
@@ -68,6 +69,7 @@ function parseIssueSeedMarkdown(text) {
     if (current && current.title && current.bodyLines.length > 0) {
       issues.push({
         title: current.title,
+        labels: current.labels,
         body: current.bodyLines.join("\n").trim(),
       });
     }
@@ -78,6 +80,7 @@ function parseIssueSeedMarkdown(text) {
       finalizeCurrent();
       current = {
         title: "",
+        labels: [],
         bodyLines: [],
       };
       section = null;
@@ -99,11 +102,28 @@ function parseIssueSeedMarkdown(text) {
       continue;
     }
 
+    if (line.trim() === "**Suggested Labels**") {
+      section = "labels";
+      continue;
+    }
+
     if (section === "title") {
       if (!line.trim()) {
         continue;
       }
       current.title = line.trim();
+      section = null;
+      continue;
+    }
+
+    if (section === "labels") {
+      if (!line.trim()) {
+        continue;
+      }
+      current.labels = line
+        .split(",")
+        .map((label) => label.trim())
+        .filter(Boolean);
       section = null;
       continue;
     }
@@ -140,6 +160,7 @@ async function createIssue(repository, issue) {
     body: JSON.stringify({
       title: issue.title,
       body: issue.body,
+      ...(issue.labels.length > 0 ? { labels: issue.labels } : {}),
     }),
   });
 
@@ -149,6 +170,19 @@ async function createIssue(repository, issue) {
   }
 
   return data;
+}
+
+function relativePath(filePath) {
+  return path.relative(ROOT_DIR, filePath) || filePath;
+}
+
+function previewText(value, maxLength = 160) {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) {
+    return compact;
+  }
+
+  return `${compact.slice(0, maxLength - 3)}...`;
 }
 
 function printUsage() {
@@ -187,10 +221,12 @@ async function main() {
   const repository = sources.github.repository;
 
   if (DRY_RUN) {
-    console.log(`Dry run for ${issues.length} issue(s) in ${repository}`);
+    console.log(`[dry-run] create GitHub issues from ${relativePath(filePath)}`);
+    console.log(`- repository: ${repository}`);
     for (const [index, issue] of issues.entries()) {
-      console.log("");
-      console.log(`${String(index + 1).padStart(2, "0")}. ${issue.title}`);
+      console.log(`- #${index + 1} ${issue.title}`);
+      console.log(`  labels: ${issue.labels.length > 0 ? issue.labels.join(", ") : "none"}`);
+      console.log(`  body: ${previewText(issue.body)}`);
     }
     return;
   }
@@ -205,10 +241,9 @@ async function main() {
     });
   }
 
-  console.log(`Created ${created.length} issue(s) in ${repository}`);
+  console.log("created GitHub issues");
   for (const issue of created) {
-    console.log(`- #${issue.number} ${issue.title}`);
-    console.log(`  ${issue.url}`);
+    console.log(`- #${issue.number} ${issue.title} ${issue.url}`);
   }
 }
 

--- a/src/create-notion-spec-from-draft.js
+++ b/src/create-notion-spec-from-draft.js
@@ -4,6 +4,7 @@ const dotenv = require("dotenv");
 
 dotenv.config();
 
+const ROOT_DIR = path.resolve(__dirname, "..");
 const STATUS_SOURCES_PATH = path.resolve(__dirname, "..", "config", "status-sources.json");
 const SPECS_DIR = path.resolve(__dirname, "..", "drafts", "specs");
 const NOTION_API_VERSION = "2022-06-28";
@@ -226,6 +227,18 @@ function toNotionBlocks(lines) {
   return blocks.slice(0, 100);
 }
 
+function relativePath(filePath) {
+  return path.relative(ROOT_DIR, filePath) || filePath;
+}
+
+function previewLines(markdown) {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
 function printUsage() {
   console.log(
     [
@@ -261,11 +274,16 @@ async function main() {
   const children = toNotionBlocks(lines);
 
   if (!APPLY_MODE) {
-    console.log(`Dry run for Notion spec creation`);
-    console.log(`- database: ${sources.notion.specsDatabaseUrl}`);
+    console.log("[dry-run] create Notion spec");
     console.log(`- title: ${title}`);
-    console.log(`- source file: ${path.relative(path.resolve(__dirname, ".."), specPath)}`);
+    console.log(`- source file: ${relativePath(specPath)}`);
+    console.log("- database: Specs");
+    console.log("- body preview:");
+    for (const line of previewLines(text)) {
+      console.log(`  ${line}`);
+    }
     console.log(`- blocks: ${children.length}`);
+    console.log(`- database url: ${sources.notion.specsDatabaseUrl}`);
     return;
   }
 
@@ -280,7 +298,10 @@ async function main() {
     }),
   });
 
-  console.log(`Created Notion spec page: ${result.url}`);
+  console.log(`created Notion spec: ${title}`);
+  if (result.url) {
+    console.log(result.url);
+  }
 }
 
 main().catch((error) => {

--- a/src/register-commands.js
+++ b/src/register-commands.js
@@ -160,13 +160,25 @@ const commands = [
     .addStringOption((option) =>
       option
         .setName("title")
-        .setDescription("企画タイトル")
-        .setRequired(true)
+        .setDescription("企画タイトル。最新の spec / issue seeds を自動解決する")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("spec_file")
+        .setDescription("drafts/specs 配下の spec ファイル名")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("issue_seed_file")
+        .setDescription("drafts/issue-seeds 配下の issue seeds ファイル名")
+        .setRequired(false)
     )
     .addBooleanOption((option) =>
       option
         .setName("dry_run")
-        .setDescription("反映はせず確認だけ行う")
+        .setDescription("true は確認のみ、false は Notion / GitHub に反映")
         .setRequired(false)
     ),
   new SlashCommandBuilder()


### PR DESCRIPTION
## Summary
- Improve `apply:bootstrap` artifact resolution with camelCase, snake_case, and kebab-case file option aliases.
- Add clearer preflight and dry-run previews for Notion Spec and GitHub Issue creation.
- Shorten Discord bootstrap/apply responses into Japanese mobile-friendly summaries.
- Document the bootstrap operation flow and record the implementation plan.

## Validation
- `node --check src/apply-bootstrap-project.js`
- `node --check src/create-notion-spec-from-draft.js`
- `node --check src/create-github-issues-from-seeds.js`
- `node --check src/bot.js`
- `node --check src/register-commands.js`
- `git diff --check`
- Verified `bootstrap:project`, `apply:bootstrap --apply`, `sync:tasks`, and Discord dry-run display manually.

## Notes
- Test draft files generated during verification were removed before commit.
- `gh` CLI was unavailable locally, so this draft PR was opened via the GitHub connector.