### PR TITLE
[codex] Map synced tasks to Notion projects

### DIFF
--- a/config/status-sources.json
+++ b/config/status-sources.json
@@ -32,6 +32,12 @@
   "notion": {
     "tasksDatabaseUrl": "https://www.notion.so/c07cd409198d4161bc1b12567d5d34c5",
     "projectsDatabaseUrl": "https://www.notion.so/c3b094ad96a648ca96734cecac9a96d4",
-    "specsDatabaseUrl": "https://www.notion.so/2f213ac9f4184272a4d9bdf956a08221"
+    "specsDatabaseUrl": "https://www.notion.so/2f213ac9f4184272a4d9bdf956a08221",
+    "projectMappings": [
+      {
+        "repository": "teympa/codex-",
+        "projectName": "Codex Ops"
+      }
+    ]
   }
 }

--- a/context.md
+++ b/context.md
@@ -41,6 +41,7 @@
 - Discord slash commands を再登録し、Bot `チャッピー#1662` の起動 ready を確認済み
 - Discord の `/codex-bootstrap-project` と `/codex-apply-bootstrap` は、スマホ確認向けに日本語の短い要約表示へ変更済み
 - Notion `Tasks` の Issue #7-#10 は `Project = Codex Ops`、`Category = Ops` に整理済み
+- `sync:tasks` は repository -> Notion Project mapping により、Project 未設定の Task だけ `Project` relation を自動補完する実装へ拡張済み
 
 ### Incomplete Items
 
@@ -90,8 +91,8 @@
 
 1. Discord から `/codex-bootstrap-project` と `/codex-apply-bootstrap` の日本語短縮表示を再確認する
 2. サンプル企画 `Bootstrap Resolution Sample` を残すか、検証用として削除するか判断する
-3. 企画テンプレートの genre / platform / audience 入力項目を実運用に合わせて拡張する
-4. 次の本物の企画で bootstrap -> apply -> sync の一連フローを試す
+3. 次の新規 Issue 作成時に `sync:tasks:dry` で Project relation 自動補完の作成予定表示を確認する
+4. 企画テンプレートの genre / platform / audience 入力項目を実運用に合わせて拡張する
 
 ## Actionable Tasks (2026-04-21)
 
@@ -187,6 +188,8 @@
 - Discord Bot は起動 ready まで確認済み。次は Discord クライアント側から dry-run 表示を確認する
 - Discord の bootstrap / apply bootstrap 返信は CLI 詳細ログをそのまま出さず、日本語の要約だけを返す
 - Notion `Tasks` の Issue #7-#10 は `Codex Ops` project に紐づけ済みで、Category は `Ops`
+- `sync:tasks` は既存 Project relation を上書きせず、未設定 Task のみ mapping で Project を補完する方針
+- `sync:tasks:dry` では既存 #1-#10 が no change で、手動 Category / Project relation を壊さないことを確認済み
 - 次回は Notion `Specs` 連携と GitHub / Notion 同期まで含めた実運用を固める
 - 情報を更新するときは、先に正本が Notion / GitHub / `context.md` のどれかを確認する
 - GitHub と Notion の二重更新は避け、`Tasks` の必要項目だけを同期する

--- a/docs/github-notion-sync-policy.md
+++ b/docs/github-notion-sync-policy.md
@@ -23,11 +23,12 @@ GitHub から Notion に反映するもの:
 - 実行状態
 - 担当
 - 主要カテゴリ
+- 未設定時の Project relation
 
 Notion にのみ残すもの:
 
 - 横断一覧で見たい補足情報
-- Project との relation
+- 手動で調整した Project relation
 - 人間向けの整理用ビュー
 
 ## Task Mapping
@@ -39,6 +40,7 @@ Notion にのみ残すもの:
 - Issue URL -> `GitHub Issue URL`
 - Labels -> `Priority` `Category` `Source`
 - State / progress -> `Status`
+- Repository mapping -> `Project` relation when the task has no existing Project
 
 ### Recommended Status Mapping
 
@@ -148,13 +150,20 @@ Notion にのみ残すもの:
 - `Category`
 - `Source`
 - `Assignee`
+- `Project` relation when empty and a repository mapping exists
 
 同期しない内容:
 
-- `Project` relation
 - `Due Date`
 - `Estimate`
 - 補足メモ
+
+Project relation の自動補完:
+
+- `config/status-sources.json` の `notion.projectMappings` で repository と Project name を対応づける
+- 既存 Task に Project relation がある場合は上書きしない
+- 対応 Project が見つからない場合は Project 未設定のまま同期し、エラーにはしない
+- GitHub ラベルから `Priority` / `Category` を判断できない場合、既存 Task の手動値は保持する
 
 安全方針:
 

--- a/src/sync-tasks.js
+++ b/src/sync-tasks.js
@@ -99,6 +99,31 @@ async function queryAllTaskPages(databaseId) {
   return results;
 }
 
+async function queryAllProjectPages(databaseId) {
+  const results = [];
+  let hasMore = true;
+  let nextCursor = undefined;
+
+  while (hasMore) {
+    const data = await notionRequest(
+      `https://api.notion.com/v1/databases/${databaseId}/query`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          page_size: 100,
+          start_cursor: nextCursor,
+        }),
+      }
+    );
+
+    results.push(...data.results);
+    hasMore = data.has_more;
+    nextCursor = data.next_cursor;
+  }
+
+  return results;
+}
+
 function getTaskTitle(properties) {
   const titleProp = properties.Task;
   if (!titleProp || titleProp.type !== "title") {
@@ -106,6 +131,44 @@ function getTaskTitle(properties) {
   }
 
   return titleProp.title.map((part) => part.plain_text).join("") || "(untitled)";
+}
+
+function getProjectTitle(properties) {
+  const titleProp = properties.Name;
+  if (!titleProp || titleProp.type !== "title") {
+    return "(untitled)";
+  }
+
+  return titleProp.title.map((part) => part.plain_text).join("") || "(untitled)";
+}
+
+function buildProjectsByName(projectPages) {
+  const projectsByName = new Map();
+  for (const page of projectPages) {
+    projectsByName.set(getProjectTitle(page.properties).toLowerCase(), page);
+  }
+  return projectsByName;
+}
+
+function findProjectMapping(sources) {
+  const mappings = Array.isArray(sources.notion?.projectMappings)
+    ? sources.notion.projectMappings
+    : [];
+
+  return mappings.find(
+    (mapping) =>
+      String(mapping.repository || "").toLowerCase() ===
+      String(sources.github.repository || "").toLowerCase()
+  );
+}
+
+function resolveDefaultProject(sources, projectsByName) {
+  const mapping = findProjectMapping(sources);
+  if (!mapping?.projectName) {
+    return null;
+  }
+
+  return projectsByName.get(mapping.projectName.toLowerCase()) || null;
 }
 
 function extractLabelNames(issue) {
@@ -244,6 +307,41 @@ function readRichText(prop) {
   return (prop?.rich_text || []).map((part) => part.plain_text).join("");
 }
 
+function hasProjectRelation(page) {
+  return (page.properties.Project?.relation || []).length > 0;
+}
+
+function addProjectRelation(properties, projectPage) {
+  if (!projectPage) {
+    return properties;
+  }
+
+  return {
+    ...properties,
+    Project: {
+      relation: [
+        {
+          id: projectPage.id,
+        },
+      ],
+    },
+  };
+}
+
+function preserveUnmappedSelectsForUpdate(properties) {
+  const nextProperties = { ...properties };
+
+  if (!nextProperties.Priority.select) {
+    delete nextProperties.Priority;
+  }
+
+  if (!nextProperties.Category.select) {
+    delete nextProperties.Category;
+  }
+
+  return nextProperties;
+}
+
 function propertiesDiffer(existingPage, desiredProperties) {
   const existing = existingPage.properties;
   const currentTitle = getTaskTitle(existing);
@@ -265,11 +363,17 @@ function propertiesDiffer(existingPage, desiredProperties) {
     return true;
   }
 
-  if (readSelectName(existing.Priority) !== (desiredProperties.Priority.select?.name || null)) {
+  if (
+    desiredProperties.Priority &&
+    readSelectName(existing.Priority) !== (desiredProperties.Priority.select?.name || null)
+  ) {
     return true;
   }
 
-  if (readSelectName(existing.Category) !== (desiredProperties.Category.select?.name || null)) {
+  if (
+    desiredProperties.Category &&
+    readSelectName(existing.Category) !== (desiredProperties.Category.select?.name || null)
+  ) {
     return true;
   }
 
@@ -281,14 +385,25 @@ function propertiesDiffer(existingPage, desiredProperties) {
     return true;
   }
 
+  if (
+    desiredProperties.Project &&
+    (existing.Project?.relation?.[0]?.id || null) !==
+      desiredProperties.Project.relation[0]?.id
+  ) {
+    return true;
+  }
+
   return false;
 }
 
-async function createTask(databaseId, issue) {
-  const properties = buildTaskProperties(issue);
+async function createTask(databaseId, issue, defaultProject) {
+  const properties = addProjectRelation(buildTaskProperties(issue), defaultProject);
 
   if (DRY_RUN) {
-    console.log(`[dry-run] create Notion task for issue #${issue.number} ${issue.title}`);
+    const projectNote = defaultProject
+      ? ` with Project ${getProjectTitle(defaultProject.properties)}`
+      : "";
+    console.log(`[dry-run] create Notion task for issue #${issue.number} ${issue.title}${projectNote}`);
     return;
   }
 
@@ -302,18 +417,29 @@ async function createTask(databaseId, issue) {
     }),
   });
 
-  console.log(`created Notion task for issue #${issue.number} ${issue.title}`);
+  const projectNote = defaultProject
+    ? ` with Project ${getProjectTitle(defaultProject.properties)}`
+    : "";
+  console.log(`created Notion task for issue #${issue.number} ${issue.title}${projectNote}`);
 }
 
-async function updateTask(pageId, issue, existingPage) {
-  const properties = buildTaskProperties(issue);
+async function updateTask(pageId, issue, existingPage, defaultProject) {
+  const shouldSetProject = defaultProject && !hasProjectRelation(existingPage);
+  const baseProperties = preserveUnmappedSelectsForUpdate(buildTaskProperties(issue));
+  const properties = shouldSetProject
+    ? addProjectRelation(baseProperties, defaultProject)
+    : baseProperties;
+
   if (!propertiesDiffer(existingPage, properties)) {
     console.log(`no change for issue #${issue.number} ${issue.title}`);
     return;
   }
 
   if (DRY_RUN) {
-    console.log(`[dry-run] update Notion task for issue #${issue.number} ${issue.title}`);
+    const projectNote = shouldSetProject
+      ? ` and set Project ${getProjectTitle(defaultProject.properties)}`
+      : "";
+    console.log(`[dry-run] update Notion task for issue #${issue.number} ${issue.title}${projectNote}`);
     return;
   }
 
@@ -322,16 +448,30 @@ async function updateTask(pageId, issue, existingPage) {
     body: JSON.stringify({ properties }),
   });
 
-  console.log(`updated Notion task for issue #${issue.number} ${issue.title}`);
+  const projectNote = shouldSetProject
+    ? ` and set Project ${getProjectTitle(defaultProject.properties)}`
+    : "";
+  console.log(`updated Notion task for issue #${issue.number} ${issue.title}${projectNote}`);
 }
 
 async function main() {
   const sources = readJson(STATUS_SOURCES_PATH);
-  const databaseId = extractIdFromNotionUrl(sources.notion.tasksDatabaseUrl);
-  const [issues, notionPages] = await Promise.all([
+  const tasksDatabaseId = extractIdFromNotionUrl(sources.notion.tasksDatabaseUrl);
+  const projectsDatabaseId = extractIdFromNotionUrl(sources.notion.projectsDatabaseUrl);
+  const [issues, notionPages, projectPages] = await Promise.all([
     fetchRepositoryIssues(sources.github.repository),
-    queryAllTaskPages(databaseId),
+    queryAllTaskPages(tasksDatabaseId),
+    queryAllProjectPages(projectsDatabaseId),
   ]);
+  const projectsByName = buildProjectsByName(projectPages);
+  const defaultProject = resolveDefaultProject(sources, projectsByName);
+  const mapping = findProjectMapping(sources);
+
+  if (mapping?.projectName && !defaultProject) {
+    console.log(
+      `Project mapping not found: ${mapping.projectName}. Project relation will not be auto-filled.`
+    );
+  }
 
   const pagesByIssueNumber = new Map();
   for (const page of notionPages) {
@@ -348,9 +488,9 @@ async function main() {
   for (const issue of issues) {
     const existingPage = pagesByIssueNumber.get(issue.number);
     if (existingPage) {
-      await updateTask(existingPage.id, issue, existingPage);
+      await updateTask(existingPage.id, issue, existingPage, defaultProject);
     } else {
-      await createTask(databaseId, issue);
+      await createTask(tasksDatabaseId, issue, defaultProject);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add repository-to-Notion Project mapping in `config/status-sources.json`.
- Auto-fill `Tasks.Project` during GitHub-to-Notion sync when the task has no existing Project relation.
- Preserve existing manual Project relations and unmapped manual `Priority` / `Category` values during updates.
- Document the updated sync behavior and refresh `context.md` handoff notes.

## Validation
- `node --check src/sync-tasks.js`
- Parsed `config/status-sources.json` as JSON
- `npm.cmd run sync:tasks:dry`
- `git diff --check`

## Notes
- Dry-run showed existing Issue #1-#10 tasks as `no change`, confirming existing manual Project/Category values are preserved.